### PR TITLE
BoardConfig.mk: Rename xq-au51 to xqau51

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -15,7 +15,7 @@
 include device/sony/seine/PlatformConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := unknown
-ifneq (,$(filter %xq-au51,$(TARGET_PRODUCT)))
+ifneq (,$(filter %xqau51,$(TARGET_PRODUCT)))
 TARGET_BOOTLOADER_BOARD_NAME := XQ-AU51
 else ifneq (,$(filter %xqau52,$(TARGET_PRODUCT)))
 TARGET_BOOTLOADER_BOARD_NAME := XQ-AU52


### PR DESCRIPTION
"-" was included in the initial bringup of the device.

This fixes the warning:
warning: Unrecognized value for TARGET_PRODUCT: "aosp_xqau51", using default value: "XQ-AU51"