### PR TITLE
[PDX201] device.mk: Add ramdisk-fstab.pdx201 to packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -68,6 +68,7 @@ PRODUCT_COPY_FILES += \
 # Device Init
 PRODUCT_PACKAGES += \
     fstab.pdx201 \
+    ramdisk-fstab.pdx201 \
     init.recovery.pdx201 \
     init.pdx201
 


### PR DESCRIPTION
This device has Dynamic Partitions: we need to copy the fstab
to the ramdisk root.

Test: Build OK - files are where expected.