### PR TITLE
[PDX201] Enable dual-mono sound, push missing audio_io_policy

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -43,7 +43,8 @@ PRODUCT_COPY_FILES += \
 
 # Audio Configuration
 PRODUCT_COPY_FILES += \
-    $(DEVICE_PATH)/vendor/etc/mixer_paths.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths.xml
+    $(DEVICE_PATH)/vendor/etc/mixer_paths.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths.xml \
+    $(DEVICE_PATH)/vendor/etc/audio_io_policy.conf:$(TARGET_COPY_OUT_VENDOR)/etc/audio_io_policy.conf
 
 # Audio calibration
 PRODUCT_COPY_FILES += \

--- a/rootdir/vendor/etc/audio_io_policy.conf
+++ b/rootdir/vendor/etc/audio_io_policy.conf
@@ -1,0 +1,105 @@
+# List of profiles for the output device session where stream is routed.
+# A stream opened with the inputs attributes which match the "flags" and
+# "formats" as specified in the profile is routed to a device at
+# sample rate specified under "sampling_rates" and bit width under
+# "bit_width" and the topology extracted from the acdb data against
+# the "app_type".
+#
+# the flags and formats are specified using the strings corresponding to
+# enums in audio.h and audio_policy.h. They are concatenated with "|"
+# without space or "\n".
+# the flags and formats should match the ones in "audio_policy.conf"
+
+outputs {
+  default {
+    flags AUDIO_OUTPUT_FLAG_PRIMARY
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69937
+  }
+  proaudio {
+    flags AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69943
+  }
+  voip_rx {
+    flags AUDIO_OUTPUT_FLAG_VOIP_RX|AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 8000|16000|32000|48000
+    bit_width 16
+    app_type 69946
+  }
+  deep_buffer {
+    flags AUDIO_OUTPUT_FLAG_DEEP_BUFFER
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 48000
+    bit_width 16
+    app_type 69936
+  }
+  direct_pcm_16 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_16_BIT|AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT|AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 16
+    app_type 69936
+  }
+  direct_pcm_24 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_8_24_BIT|AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|88200|96000|176400|192000|352800|384000
+    bit_width 24
+    app_type 69940
+  }
+  direct_pcm_32 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT
+    formats AUDIO_FORMAT_PCM_32_BIT
+    sampling_rates 44100|48000|88200|96000|176400|192000|352800|384000
+    bit_width 32
+    app_type 69942
+  }
+  compress_passthrough {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING|AUDIO_OUTPUT_FLAG_COMPRESS_PASSTHROUGH
+    formats AUDIO_FORMAT_DTS|AUDIO_FORMAT_DTS_HD|AUDIO_FORMAT_DSD
+    sampling_rates 32000|44100|48000|88200|96000|176400|192000|352800
+    bit_width 16
+    app_type 69941
+  }
+  compress_offload_16 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING
+    formats AUDIO_FORMAT_MP3|AUDIO_FORMAT_PCM_16_BIT_OFFLOAD|AUDIO_FORMAT_PCM_24_BIT_OFFLOAD|AUDIO_FORMAT_FLAC|AUDIO_FORMAT_ALAC|AUDIO_FORMAT_APE|AUDIO_FORMAT_AAC_LC|AUDIO_FORMAT_AAC_HE_V1|AUDIO_FORMAT_AAC_HE_V2|AUDIO_FORMAT_WMA|AUDIO_FORMAT_WMA_PRO|AUDIO_FORMAT_VORBIS|AUDIO_FORMAT_AAC_ADTS_LC|AUDIO_FORMAT_AAC_ADTS_HE_V1|AUDIO_FORMAT_AAC_ADTS_HE_V2
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 16
+    app_type 69936
+  }
+  compress_offload_24 {
+    flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING
+    formats AUDIO_FORMAT_PCM_24_BIT_OFFLOAD|AUDIO_FORMAT_FLAC|AUDIO_FORMAT_ALAC|AUDIO_FORMAT_APE|AUDIO_FORMAT_VORBIS|AUDIO_FORMAT_WMA|AUDIO_FORMAT_WMA_PRO
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 24
+    app_type 69940
+  }
+}
+
+inputs {
+  record_16bit {
+    formats AUDIO_FORMAT_PCM_16_BIT
+    sampling_rates 8000|16000|32000|44100|48000|88200|96000|176400|192000
+    bit_width 16
+    app_type 69938
+  }
+  record_24bit {
+    formats AUDIO_FORMAT_PCM_24_BIT_PACKED|AUDIO_FORMAT_PCM_24_BIT
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 24
+    app_type 69948
+  }
+  record_32bit {
+    formats AUDIO_FORMAT_PCM_32_BIT|AUDIO_FORMAT_PCM_FLOAT
+    sampling_rates 44100|48000|88200|96000|176400|192000
+    bit_width 32
+    app_type 69949
+  }
+}

--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -503,6 +503,7 @@
 
     <path name="deep-buffer-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia1" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback handset">
@@ -598,6 +599,7 @@
 
     <path name="low-latency-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia5" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback handset">
@@ -697,6 +699,7 @@
 
     <path name="audio-ull-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia3" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback handset">
@@ -798,6 +801,7 @@
 
     <path name="compress-offload-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia4" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia4" value="1" />
     </path>
 
     <path name="compress-offload-playback handset">
@@ -913,10 +917,12 @@
 
     <path name="compress-offload-playback2">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 voice-speaker-stereo">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 handset">
@@ -1024,6 +1030,7 @@
 
     <path name="compress-offload-playback3">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia10" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia10" value="1" />
     </path>
 
     <path name="compress-offload-playback3 handset">
@@ -1115,6 +1122,7 @@
 
     <path name="compress-offload-playback4">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia11" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia11" value="1" />
     </path>
 
     <path name="compress-offload-playback4 handset">
@@ -1226,6 +1234,7 @@
 
     <path name="compress-offload-playback5">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia12" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia12" value="1" />
     </path>
 
     <path name="compress-offload-playback5 handset">
@@ -1341,6 +1350,7 @@
 
     <path name="compress-offload-playback6">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia13" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia13" value="1" />
     </path>
 
     <path name="compress-offload-playback6 handset">
@@ -1436,6 +1446,7 @@
 
     <path name="compress-offload-playback7">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia14" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia14" value="1" />
     </path>
 
     <path name="compress-offload-playback7 handset">
@@ -1532,6 +1543,7 @@
 
     <path name="compress-offload-playback8">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia15" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia15" value="1" />
     </path>
 
     <path name="compress-offload-playback8 handset">
@@ -1627,6 +1639,7 @@
 
     <path name="compress-offload-playback9">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
     </path>
 
     <path name="compress-offload-playback9 handset">
@@ -2498,6 +2511,7 @@
 
     <path name="mmap-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
      </path>
 
     <path name="mmap-playback handset">
@@ -2765,8 +2779,24 @@
         <ctl name="TX DMIC MUX0" value="DMIC3" />
     </path>
 
+    <path name="handset-as-speaker">
+        <ctl name="RX_MACRO RX0 MUX" value="AIF1_PB" />
+        <ctl name="RX_CDC_DMA_RX_0 Channels" value="One" />
+        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="EAR_RDAC Switch" value="1" />
+        <ctl name="RDAC3_MUX" value="RX1" />
+		<ctl name="RX_RX0 Digital Volume" value="92" />
+    </path>
+
     <path name="speaker">
         <ctl name="PCM Source" value="DSP" />
+        <path name="handset-as-speaker" />
+    </path>
+
+    <path name="speaker-stereo">
+        <path name="handset-as-speaker" />
+        <path name="speaker" />
     </path>
 
     <path name="speaker-mono">
@@ -3492,3 +3522,4 @@
     </path>
 
 </mixer>
+


### PR DESCRIPTION
This device's earpiece is powerful enough and good enough to
function as a speaker: let's enable it for all speaker usecases.
Also, add the missing audio_io_policy.conf.

P.S.: I've tested the frequency response of the earpiece while
it's being driven "high": it's not perfect, but it's fine really, that's
totally usable... no crackles and no bad distortions.

Tested on Sony Seine PDX201 DSDS