### PR TITLE
Revert dual-mono speaker configuration

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -503,7 +503,6 @@
 
     <path name="deep-buffer-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia1" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback handset">
@@ -599,7 +598,6 @@
 
     <path name="low-latency-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia5" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback handset">
@@ -699,7 +697,6 @@
 
     <path name="audio-ull-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia3" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback handset">
@@ -801,7 +798,6 @@
 
     <path name="compress-offload-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia4" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia4" value="1" />
     </path>
 
     <path name="compress-offload-playback handset">
@@ -917,12 +913,10 @@
 
     <path name="compress-offload-playback2">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 voice-speaker-stereo">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 handset">
@@ -1030,7 +1024,6 @@
 
     <path name="compress-offload-playback3">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia10" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia10" value="1" />
     </path>
 
     <path name="compress-offload-playback3 handset">
@@ -1122,7 +1115,6 @@
 
     <path name="compress-offload-playback4">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia11" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia11" value="1" />
     </path>
 
     <path name="compress-offload-playback4 handset">
@@ -1234,7 +1226,6 @@
 
     <path name="compress-offload-playback5">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia12" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia12" value="1" />
     </path>
 
     <path name="compress-offload-playback5 handset">
@@ -1350,7 +1341,6 @@
 
     <path name="compress-offload-playback6">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia13" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia13" value="1" />
     </path>
 
     <path name="compress-offload-playback6 handset">
@@ -1446,7 +1436,6 @@
 
     <path name="compress-offload-playback7">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia14" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia14" value="1" />
     </path>
 
     <path name="compress-offload-playback7 handset">
@@ -1543,7 +1532,6 @@
 
     <path name="compress-offload-playback8">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia15" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia15" value="1" />
     </path>
 
     <path name="compress-offload-playback8 handset">
@@ -1639,7 +1627,6 @@
 
     <path name="compress-offload-playback9">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
     </path>
 
     <path name="compress-offload-playback9 handset">
@@ -2511,7 +2498,6 @@
 
     <path name="mmap-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
-        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
      </path>
 
     <path name="mmap-playback handset">
@@ -2779,24 +2765,8 @@
         <ctl name="TX DMIC MUX0" value="DMIC3" />
     </path>
 
-    <path name="handset-as-speaker">
-        <ctl name="RX_MACRO RX0 MUX" value="AIF1_PB" />
-        <ctl name="RX_CDC_DMA_RX_0 Channels" value="One" />
-        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="EAR_RDAC Switch" value="1" />
-        <ctl name="RDAC3_MUX" value="RX1" />
-		<ctl name="RX_RX0 Digital Volume" value="92" />
-    </path>
-
     <path name="speaker">
         <ctl name="PCM Source" value="DSP" />
-        <path name="handset-as-speaker" />
-    </path>
-
-    <path name="speaker-stereo">
-        <path name="handset-as-speaker" />
-        <path name="speaker" />
     </path>
 
     <path name="speaker-mono">
@@ -3526,4 +3496,3 @@
     </path>
 
 </mixer>
-


### PR DESCRIPTION
Unfortunately this configuration doesn't seem to work for everyone,
resulting in backend initialization failures that break audio in every
usecase except compressed offload playback...:

    E __afe_port_start: AFE enable for port 0xb030 failed -22
    E msm-dai-cdc-dma-dev soc: qcom,msm-dai-cdc-dma:qcom,msm-dai-rx-cdc-dma-0-rx: fail to open AFE port 0xb030
    E msm-dai-cdc-dma-dev soc: qcom,msm-dai-cdc-dma:qcom,msm-dai-rx-cdc-dma-0-rx: ASoC: cpu DAI prepare error: -22
    E soc_pcm_prepare: Issue stop stream for codec_dai due to op failure -22 = ret

Revert it for now until we find time to properly debug and re-enable
this feature.

This reverts commit f58e3ae0f49b99bc1117540321034e8aefb5bcab.
