### PR TITLE
[PDX201] Re-enable dual-mono

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -2784,11 +2784,6 @@
         <path name="handset-as-speaker" />
     </path>
 
-    <path name="speaker-stereo">
-        <path name="handset-as-speaker" />
-        <path name="speaker" />
-    </path>
-
     <path name="speaker-mono">
         <path name="speaker" />
     </path>

--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -503,6 +503,7 @@
 
     <path name="deep-buffer-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia1" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback handset">
@@ -598,6 +599,7 @@
 
     <path name="low-latency-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia5" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback handset">
@@ -697,6 +699,7 @@
 
     <path name="audio-ull-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia3" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback handset">
@@ -798,6 +801,7 @@
 
     <path name="compress-offload-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia4" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia4" value="1" />
     </path>
 
     <path name="compress-offload-playback handset">
@@ -913,10 +917,12 @@
 
     <path name="compress-offload-playback2">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 voice-speaker-stereo">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia7" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 handset">
@@ -1024,6 +1030,7 @@
 
     <path name="compress-offload-playback3">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia10" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia10" value="1" />
     </path>
 
     <path name="compress-offload-playback3 handset">
@@ -1115,6 +1122,7 @@
 
     <path name="compress-offload-playback4">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia11" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia11" value="1" />
     </path>
 
     <path name="compress-offload-playback4 handset">
@@ -1226,6 +1234,7 @@
 
     <path name="compress-offload-playback5">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia12" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia12" value="1" />
     </path>
 
     <path name="compress-offload-playback5 handset">
@@ -1341,6 +1350,7 @@
 
     <path name="compress-offload-playback6">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia13" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia13" value="1" />
     </path>
 
     <path name="compress-offload-playback6 handset">
@@ -1436,6 +1446,7 @@
 
     <path name="compress-offload-playback7">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia14" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia14" value="1" />
     </path>
 
     <path name="compress-offload-playback7 handset">
@@ -1532,6 +1543,7 @@
 
     <path name="compress-offload-playback8">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia15" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia15" value="1" />
     </path>
 
     <path name="compress-offload-playback8 handset">
@@ -1627,6 +1639,7 @@
 
     <path name="compress-offload-playback9">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
     </path>
 
     <path name="compress-offload-playback9 handset">
@@ -2498,6 +2511,7 @@
 
     <path name="mmap-playback">
         <ctl name="PRI_MI2S_RX Audio Mixer MultiMedia16" value="1" />
+        <ctl name="RX_CDC_DMA_RX_0 Audio Mixer MultiMedia16" value="1" />
      </path>
 
     <path name="mmap-playback handset">
@@ -2755,8 +2769,24 @@
         <ctl name="TX DMIC MUX0" value="DMIC3" />
     </path>
 
+    <path name="handset-as-speaker">
+        <ctl name="RX_MACRO RX0 MUX" value="AIF1_PB" />
+        <ctl name="RX_CDC_DMA_RX_0 Channels" value="One" />
+        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="EAR_RDAC Switch" value="1" />
+        <ctl name="RDAC3_MUX" value="RX1" />
+        <ctl name="RX_RX0 Digital Volume" value="92" />
+    </path>
+
     <path name="speaker">
         <ctl name="PCM Source" value="DSP" />
+        <path name="handset-as-speaker" />
+    </path>
+
+    <path name="speaker-stereo">
+        <path name="handset-as-speaker" />
+        <path name="speaker" />
     </path>
 
     <path name="speaker-mono">


### PR DESCRIPTION
Requires https://github.com/sonyxperiadev/vendor-qcom-opensource-audio-hal-primary-hal/pull/7

This configuration was causing issues because the `"speaker"` path wasn't being selected by the HAL (`cirrus_sony` `spkr_prot` is responsible for that). Only `RX_CDC_DMA_RX_0` mixers were getting configured leading to errors; the ctls in `"handset-as-speaker"` are mandatory but were left at their defaults.

Now that this issue is resolved and the path is selected again we can safely re-enable dual-mono.

Note that this configuration ~ remains ~ dual mono. True stereo is being worked on, and might be submitted soon.