### PR TITLE
[master] pdx201: Support LTE by default for second sim card

### DIFF
--- a/aosp_xqau52.mk
+++ b/aosp_xqau52.mk
@@ -16,7 +16,7 @@
 PRODUCT_DEVICE_DS := true
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.telephony.default_network=9,0
+    ro.telephony.default_network=9,9
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/pdx201/aosp_xqau51.mk)


### PR DESCRIPTION
SM6125 already support dual cards stay on LTE, so enable it by default.
```
9 = LTE, GSM and WCDMA
0 = GSM, WCDMA
```
TD-SCDMA is out of date, and Xperia doesn't support CDMA, EVDO at all.

https://android.googlesource.com/platform/frameworks/base/+/android-11.0.0_r1/telephony/java/com/android/internal/telephony/RILConstants.java#162
