### PR TITLE
[master] pdx201: Override fstab suffix

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,7 +27,9 @@ endif
 # Platform
 PRODUCT_PLATFORM := seine
 
+# Kernel cmdline
 BOARD_KERNEL_CMDLINE += androidboot.hardware=pdx201
+BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx201
 
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)


### PR DESCRIPTION
Tested on stock Android 11 59.1.A.0.485 firmware

The bootloader of stock 11 had hardcode `androidboot.fstab_suffix=emmc`, this config will make init load
`fstab.emmc` in ramdisk, but fstab used by Open devices is `fstab.{DEVICE_NAME}`. So we need to override
`androidboot.fstab_suffix=pdx201` to load the correct fstab file.

Here is the log after overriding:

`03-17 02:59:38.254     0     0 I         : Kernel command line: rcupdate.rcu_expedited=1 rcu_nocbs=0-7 androidboot.hardware=qcom androidboot.memcg=1 lpm_levels.sleep_disabled=1 video=vfb:640x400,bpp=32,memsize=3072000 msm_rtb.filter=0x237 service_locator.enable=1 swiotlb=1 loop.max_part=7 cgroup.memory=nokmem,nosocket buildproduct=pdx201 buildid=SEINE-1.1.0-210112-1356 oemboot.earlymount=/dev/block/platform/soc/4744000.sdhci/by-name/oem:/mnt/oem:ext4:ro,barrier=1:wait,slotselect,first_stage_mount androidboot.fstab_suffix=qcom buildvariant=userdebug androidboot.verifiedbootstate=orange androidboot.keymaster=1  androidboot.bootdevice=4744000.sdhci androidboot.fstab_suffix=emmc androidboot.boot_devices=soc/4744000.sdhci androidboot.baseband=msm msm_drm.dsi_display0=6: androidboot.slot_suffix=_a rootwait ro init=/init androidboot.dtbo_idx=0 androidboot.dtb_idx=7  androidboot.bootloader=xboot oemandroidboot.xboot=1320-2835_X_Boot_SM6125_LA2.0.1_R_113 androidboot.serialno=QV722JV73A oemandroidboot.babe08a4=318 startup=0x00`

...

`03-17 02:59:41.533     0     0 E init    : Init cannot set 'ro.boot.fstab_suffix' to 'emmc': Read-only property was already set`