### PR TITLE
overlay: power_profile: Fix battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -71,7 +71,7 @@
     <array name="memory.bandwidths">
         <value>22.7</value>
     </array>
-    <item name="battery.capacity">3460</item>
+    <item name="battery.capacity">3600</item>
     <item name="wifi.controller.idle">0.19</item>
     <item name="wifi.controller.rx">148.18</item>
     <item name="wifi.controller.tx">395.03</item>


### PR DESCRIPTION
Xperia 10II battery capacity is 3600mAh and not 3460mAh.

Change this value so system reports correct value.

Please cherry-pick this to q-mr1 and master as well.